### PR TITLE
Fix rotate implementation for non-square pieces

### DIFF
--- a/battleship_game/src/piece.py
+++ b/battleship_game/src/piece.py
@@ -16,7 +16,7 @@ class Piece:
 
     # Rotates the piece 90 degrees to the left
     def rotated_left(self) -> Self:
-        rows = self.columns()
+        rows = self.rows()
         cols = self.columns()
         # The new shape has the same dimensions as the old shape transposed
         shape = [[False for _ in range(rows)] for _ in range(cols)]
@@ -28,7 +28,7 @@ class Piece:
         return Piece(shape)
 
     def rotated_right(self) -> Self:
-        rows = self.columns()
+        rows = self.rows()
         cols = self.columns()
         # The new shape has the same dimensions as the old shape transposed
         shape = [[False for _ in range(rows)] for _ in range(cols)]

--- a/battleship_game/src/test_piece.py
+++ b/battleship_game/src/test_piece.py
@@ -15,6 +15,17 @@ class TestPieceMethods(unittest.TestCase):
                 [True, False]
             ])
         )
+    
+    def test_rotate_left_long(self):
+        self.assertEqual(
+            piece.Piece([
+                [True, False]
+            ]).rotated_left(),
+            piece.Piece([
+                [True], 
+                [False]
+            ])
+        )
 
     def test_rotate_right(self):
         self.assertEqual(
@@ -25,6 +36,17 @@ class TestPieceMethods(unittest.TestCase):
             piece.Piece([
                 [False, True], 
                 [False, False]
+            ])
+        )
+
+    def test_rotate_right_long(self):
+        self.assertEqual(
+            piece.Piece([
+                [True, False]
+            ]).rotated_left(),
+            piece.Piece([
+                [False], 
+                [True]
             ])
         )
 


### PR DESCRIPTION
I noticed a bug in the rotate implementation that breaks when the number of rows and columns are not the same. This PR fixes that issue and adds more tests